### PR TITLE
Add agent to opbeans-dotnet

### DIFF
--- a/opbeans-dotnet/Startup.cs
+++ b/opbeans-dotnet/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using AutoMapper;
+using Elastic.Apm.All;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -36,6 +37,8 @@ namespace OpbeansDotnet
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 		{
+			app.UseElasticApm();
+
 			Mapper.Initialize(cfg =>
 			{
 				cfg.CreateMap<Orders, Order>()

--- a/opbeans-dotnet/opbeans-dotnet.csproj
+++ b/opbeans-dotnet/opbeans-dotnet.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="8.0.0" />
+        <PackageReference Include="Elastic.Apm.All" Version="0.0.2-alpha" />
         <PackageReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.0" />


### PR DESCRIPTION
This PR adds the agent to the opbeans sample project.

It's fetched from nuget. The default nuget feed is usually nuget.org, so by default this will fetch the latest public release (specifically [this package](http://nuget.org/packages/Elastic.Apm.All/0.0.2-alpha)).

In case we want to fetch it from our AppVeyor we need to add that as the primary nuget feed. 