### PR TITLE
Make agent read appsetting.json file

### DIFF
--- a/opbeans-dotnet/Startup.cs
+++ b/opbeans-dotnet/Startup.cs
@@ -37,7 +37,7 @@ namespace OpbeansDotnet
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 		{
-			app.UseElasticApm();
+			app.UseElasticApm(Configuration);
 
 			Mapper.Initialize(cfg =>
 			{


### PR DESCRIPTION
Without passing the `IConfiguration` to `UseElasticApm` the agent doesn't read `appsettings.json`