### PR TITLE
ci(jenkins): avoid abort when timeout the release input approval

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -88,11 +88,11 @@ pipeline {
             }
           }
         }
-        stage('Release') {
+        stage('Release approval') {
           options {
             skipDefaultCheckout()
             timeout(time: 12, unit: 'SECONDS')
-            warnError('The release was not done')
+            catchError( message: 'The release was not approved', buildResult: 'SUCCESS', stageResult: 'ABORTED', catchInterruptions: false)
           }
           input {
             message 'Should we release a new version?'
@@ -115,12 +115,41 @@ pipeline {
             }
           }
           steps {
-            withGithubNotify(context: 'Release') {
-              deleteDir()
-              unstash 'source'
-              dir("${BASE_DIR}"){
-                dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
-                sh "VERSION=${VERSION} make publish"
+            script {
+              sh 'env | sort'
+              env.VERSION = "${env.VERSION}"
+              sh 'env | sort'
+            }
+          }
+        }
+        stage('Release') {
+          options {
+            skipDefaultCheckout()
+            timeout(time: 1, unit: 'HOURS')
+          }
+          when {
+            beforeInput true
+            beforeAgent true
+            allOf {
+              anyOf {
+                branch 'master'
+                branch "\\d+\\.\\d+"
+                branch "v\\d?"
+                tag "v\\d+\\.\\d+\\.\\d+*"
+                expression { return !params.Run_As_Master_Branch }  // TODO: reverse logic
+              }
+              expression { env.VERSION != null }
+            }
+          }
+          steps {
+              withGithubNotify(context: 'Release') {
+                deleteDir()
+                unstash 'source'
+                dir("${BASE_DIR}"){
+                  sh 'env | sort'
+                  dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
+                  //sh "VERSION=${VERSION} make publish"  // TODO: uncomment
+                }
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -142,14 +142,13 @@ pipeline {
             }
           }
           steps {
-              withGithubNotify(context: 'Release') {
-                deleteDir()
-                unstash 'source'
-                dir("${BASE_DIR}"){
-                  sh 'env | sort'
-                  dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
-                  //sh "VERSION=${VERSION} make publish"  // TODO: uncomment
-                }
+            withGithubNotify(context: 'Release') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                sh 'env | sort'
+                dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
+                //sh "VERSION=${VERSION} make publish"  // TODO: uncomment
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
           options {
             skipDefaultCheckout()
             timeout(time: 12, unit: 'SECONDS')
-            catchError(message: 'The release was not approved', buildResult: 'SUCCESS', stageResult: 'ABORTED', catchInterruptions: true)
+            catchError(message: 'The release was not approved', buildResult: 'SUCCESS', stageResult: 'UNSTABLE', catchInterruptions: true)
           }
           input {
             message 'Should we release a new version?'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -91,8 +91,8 @@ pipeline {
         stage('Release') {
           options {
             skipDefaultCheckout()
-            timeout(time: 12, unit: 'HOURS')
-            warnError('The Release was not make')
+            timeout(time: 12, unit: 'SECONDS')
+            warnError('The release was not done')
           }
           input {
             message 'Should we release a new version?'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -136,7 +136,7 @@ pipeline {
                 branch "\\d+\\.\\d+"
                 branch "v\\d?"
                 tag "v\\d+\\.\\d+\\.\\d+*"
-                expression { return !params.Run_As_Master_Branch }  // TODO: reverse logic
+                expression { return params.Run_As_Master_Branch }
               }
               expression { env.VERSION != null }
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
           options {
             skipDefaultCheckout()
             timeout(time: 12, unit: 'SECONDS')
-            catchError( message: 'The release was not approved', buildResult: 'SUCCESS', stageResult: 'ABORTED', catchInterruptions: false)
+            catchError(message: 'The release was not approved', buildResult: 'SUCCESS', stageResult: 'ABORTED', catchInterruptions: true)
           }
           input {
             message 'Should we release a new version?'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -12,7 +12,6 @@ pipeline {
     PIPELINE_LOG_LEVEL = 'INFO'
   }
   options {
-    timeout(time: 1, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
@@ -50,6 +49,10 @@ pipeline {
         Build the project from code..
         */
         stage('Build') {
+          options {
+            timeout(time: 1, unit: 'HOURS')
+            skipDefaultCheckout()
+          }
           steps {
             withGithubNotify(context: 'Build') {
               deleteDir()
@@ -64,6 +67,10 @@ pipeline {
         Execute unit tests.
         */
         stage('Test') {
+          options {
+            timeout(time: 1, unit: 'HOURS')
+            skipDefaultCheckout()
+          }
           steps {
             withGithubNotify(context: 'Test', tab: 'tests') {
               deleteDir()
@@ -82,6 +89,11 @@ pipeline {
           }
         }
         stage('Release') {
+          options {
+            skipDefaultCheckout()
+            timeout(time: 12, unit: 'HOURS')
+            warnError('The Release was not make')
+          }
           input {
             message 'Should we release a new version?'
             ok 'Yes, we should.'


### PR DESCRIPTION
## Highlights
- Avoid aborting when a timeout happens during the input approval
- Timeout moved to 12 hours in the input approval.

## Notes
- This implementation doesn't change the status but keeping the build as aborted.