### PR TITLE
Update opbeans-dotnet/opbeans-dotnet.csproj

### DIFF
--- a/opbeans-dotnet/opbeans-dotnet.csproj
+++ b/opbeans-dotnet/opbeans-dotnet.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="8.0.0" />
-        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.0.0-beta1" />
+        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.0" />


### PR DESCRIPTION
Update version to the last release.

`Elastic.Apm.NetCoreAll` `Version="1.0.0-beta1` was never really released, that's why we had warnings in CI. 