### PR TITLE
Set environment

### DIFF
--- a/opbeans-dotnet/appsettings.json
+++ b/opbeans-dotnet/appsettings.json
@@ -4,5 +4,9 @@
       "Default": "Warning"
     }
   },
+  "ElasticApm": 
+  {
+    "Environment": "production"
+  },
   "AllowedHosts": "*"
 }

--- a/opbeans-dotnet/opbeans-dotnet.csproj
+++ b/opbeans-dotnet/opbeans-dotnet.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="8.0.0" />
-        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.0.0-beta1" />
+        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.0" />

--- a/opbeans-dotnet/opbeans-dotnet.csproj
+++ b/opbeans-dotnet/opbeans-dotnet.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="8.0.0" />
-        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.0.0" />
+        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.0" />


### PR DESCRIPTION
@watson pinged us with this message:

> I just saw that the opbeans-dotnet app sets he environment property to Production (with uppercase P). For demo purposes it would be prettier if it was with a lower-case "p" so it would be grouped together with the other production apps from the other languages

He is right, this is because by default, in case nothing is configured (and this was the case here) we read the environment from [IHostingEnvironment.EnvironmentName](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.ihostingenvironment.environmentname?view=aspnetcore-2.2) and that seems to return `Production` by default. 

So in this PR I set it manually. @v1v I remember we replace the `appsettings.json` file in some docker setup - could we make sure that during that magic we also set the `"Environment": "production"` part? 