### PR TITLE
lighter docker image for the obpeans-dotnet

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,15 @@
+.ci
+.dockerignore
+.editorconfig
 .git
+.gitignore
+.gitmodules
 .idea
 .vscode
+docker-compose*.yml
 Dockerfile
 Makefile
+README.md
 tests
 bats
+target

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,7 @@ WORKDIR /src
 RUN dotnet restore
 RUN dotnet publish -c Release -o out
 
-## Alpine image produces a segmentation fault:
-##        further details: https://github.com/aspnet/EntityFrameworkCore/issues/14504
-## FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
 WORKDIR /app
 COPY --from=build /src/opbeans-dotnet/out ./
 COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend


### PR DESCRIPTION
## Highlights
- Alpine is now available
- Docker image size from `300mb` to `200mb`