### PR TITLE
Bump version 1.4.0

### DIFF
--- a/opbeans-dotnet/opbeans-dotnet.csproj
+++ b/opbeans-dotnet/opbeans-dotnet.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="8.0.0" />
-        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.3.1" />
+        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.0" />


### PR DESCRIPTION
Hopefully the last manual bump.

Caused by https://apm-ci.elastic.co/job/apm-agent-dotnet/job/apm-agent-dotnet-mbp/job/1.4.0/