### PR TITLE
docker: fix healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       apm-server:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -s http://localhost"]
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:80/ || exit 1"]
       retries: 10
       interval: 20s
 


### PR DESCRIPTION
Fixes the issue when running docker-compose since curl is not installed in the docker image


```bash
$ docker-compose up -d
$ docker inspect opbeans-dotnet | jq -r '.[0].State.Health'
{
                "Status": "starting",
                "FailingStreak": 5,
                "Log": [
                    {
                        "Start": "2020-06-30T11:54:33.879775Z",
                        "End": "2020-06-30T11:54:33.9718698Z",
                        "ExitCode": 127,
                        "Output": "/bin/sh: curl: not found\n"
                    },
```

With this fix

```bash
$ docker-compose up -d
$ docker inspect opbeans-dotnet | jq -r '.[0].State.Health'
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2020-06-30T11:58:15.3249039Z",
      "End": "2020-06-30T11:58:15.4194588Z",
      "ExitCode": 0,
      "Output": ""
    }

```