### PR TITLE
docker: add labels metadata

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -16,7 +16,6 @@ docker run --rm -t \
 ## Bump agent version in the Dockerfile
 sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
 
-exit 0
 # Commit changes
 git add opbeans-dotnet/opbeans-dotnet.csproj Dockerfile
 git commit -m "Bump version ${AGENT_VERSION}"

--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -14,7 +14,7 @@ docker run --rm -t \
     dotnet add package Elastic.Apm.NetCoreAll -v ${AGENT_VERSION}"
 
 ## Bump agent version in the Dockerfile
-sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(\".*\"\)\(.*\)#\1\"${AGENT_VERSION}\"\3#g" Dockerfile
 
 # Commit changes
 git add opbeans-dotnet/opbeans-dotnet.csproj Dockerfile

--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -13,6 +13,10 @@ docker run --rm -t \
   mcr.microsoft.com/dotnet/core/sdk:2.2 /bin/sh -c "
     dotnet add package Elastic.Apm.NetCoreAll -v ${AGENT_VERSION}"
 
+## Bump agent version in the Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
+
+exit 0
 # Commit changes
-git add opbeans-dotnet/opbeans-dotnet.csproj
+git add opbeans-dotnet/opbeans-dotnet.csproj Dockerfile
 git commit -m "Bump version ${AGENT_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend
 LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
-    org.label-schema.name="opbeans-donet" \
+    org.label-schema.name="opbeans-dotnet" \
     org.label-schema.version="1.5.1" \
     org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-dotnet" \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-dotnet" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,15 @@ FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine AS runtime
 WORKDIR /app
 COPY --from=build /src/opbeans-dotnet/out ./
 COPY --from=opbeans/opbeans-frontend:latest /app/build /opbeans-frontend
+
+LABEL \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.vendor="Elastic" \
+    org.label-schema.name="opbeans-donet" \
+    org.label-schema.version="1.5.1" \
+    org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-dotnet" \
+    org.label-schema.vcs-url="https://github.com/elastic/opbeans-dotnet" \
+    org.label-schema.license="MIT"
+
 EXPOSE 80
 ENTRYPOINT ["dotnet", "opbeans-dotnet.dll"]


### PR DESCRIPTION
Added some labels to easily identify what's the agent version that the opbeans is consuming, in addition to some labels that are generated for some other Elastic docker images.


### Tests
- docker inspect

```bash
$ docker pull docker.elastic.co/observability-ci/opbeans-dotnet:e94afd7840321e880a3a4032675c1bb0472179d5
$ docker inspect docker.elastic.co/observability-ci/opbeans-dotnet:e94afd7840321e880a3a4032675c1bb0472179d5 | jq -r '.[0].Config.Labels'
{
  "org.label-schema.license": "MIT",
  "org.label-schema.name": "opbeans-dotnet",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://hub.docker.com/r/opbeans/opbeans-dotnet",
  "org.label-schema.vcs-url": "https://github.com/elastic/opbeans-dotnet",
  "org.label-schema.vendor": "Elastic",
  "org.label-schema.version": "1.5.1"
}

```
