### PR TITLE
Bump version to 1.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
     org.label-schema.name="opbeans-dotnet" \
-    org.label-schema.version="1.8.1" \
+    org.label-schema.version="1.11.1" \
     org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-dotnet" \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-dotnet" \
     org.label-schema.license="MIT"

--- a/opbeans-dotnet/opbeans-dotnet.csproj
+++ b/opbeans-dotnet/opbeans-dotnet.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="8.0.0" />
-        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.10.0" />
+        <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.11.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.0" />
     </ItemGroup>
 


### PR DESCRIPTION
This should not be merged [until the 1.11.1 release](https://github.com/elastic/apm-agent-dotnet/releases/tag/untagged-b6742a742f8e28d7864b) is done.

After this is merged, a corresponding tag should be pushed.
